### PR TITLE
Use PyPI OIDC

### DIFF
--- a/.github/workflows/testing-and-deployment.yaml
+++ b/.github/workflows/testing-and-deployment.yaml
@@ -88,14 +88,33 @@ jobs:
           python -m build
           twine check --strict dist/*
 
-      - name: Upload to PyPi
-        if: matrix.python-version == '3.9' && startsWith(github.ref, 'refs/tags/v')
+  pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [Linux, macOS, windows]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/npt-promote
+    permissions:
+      id-token: write # this permission is mandatory for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build package
         run: |
-          twine upload --skip-existing dist/npt_promote*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-          TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
+          pip install build
+          python -m build
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
   windows:
     name: Windows Unit Testing


### PR DESCRIPTION
## Summary

Migrate PyPI publishing from token-based `twine upload` (wired inside the Linux test matrix) to OIDC Trusted Publishing via a dedicated `pypi` job using `pypa/gh-action-pypi-publish`. Removes reliance on `PYPI_TOKEN` and adds `permissions: id-token: write` plus `environment: pypi`.

## Next steps

- [ ] Add a Trusted Publisher on PyPI for this project: Account → Publishing → Add a new publisher (workflow: `testing-and-deployment.yaml`, environment: `pypi`).
- [ ] Add `npt-promote` to the `pyvista` PyPI organization.
- [ ] After first successful OIDC release, delete the old PyPI API token and revoke the `PYPI_TOKEN` Actions secret.